### PR TITLE
chore: update docker-cd workflow to v0.0.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     name: Deploy
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@v0.0.26 # v0.0.25
     with:
       app-path: apps/close-powerlifting
       service-name: close-powerlifting
@@ -165,7 +165,7 @@ jobs:
     needs: temp-build
     permissions:
       deployments: write
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-deploy.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-deploy.yaml@v0.0.26 # v0.0.25
     with:
       app-path: apps/close-powerlifting
       service-name: close-powerlifting

--- a/.github/workflows/temp-cleanup.yml
+++ b/.github/workflows/temp-cleanup.yml
@@ -26,7 +26,7 @@ jobs:
     if: >
       github.event.action == 'closed' ||
       (github.event.action == 'unlabeled' && github.event.label.name == 'temp-deploy')
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-cleanup.yaml@ed0bda2409dae9b929fafb7327b199e34ae83b27 # v0.0.25
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/temp-cleanup.yaml@v0.0.26 # v0.0.25
     with:
       app-path: apps/close-powerlifting
     secrets:


### PR DESCRIPTION
Updates pinned `wajeht/docker-cd-deploy-workflow` references to `v0.0.26`.

This picks up the temp deploy change that writes `x-docker-cd` config into the generated compose file instead of creating `docker-cd.yml`.