### PR TITLE
perf: tune sqlite snapshot runtime

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,7 +1,7 @@
 name: Update OPL Database
 
 # Re-parses OpenPowerlifting's nightly bulk CSV into our runtime SQLite
-# database and publishes it as an asset on the `snapshot-latest` GitHub Release.
+# database and publishes it as a compressed asset on the `snapshot-latest` GitHub Release.
 # The Dockerfile fetches these assets at image-build time, so the
 # database lives entirely outside the git history — no LFS, no quota
 # pressure, no 700 MB blobs in the repo.
@@ -37,6 +37,9 @@ jobs:
       - name: Build database
         run: npm run database:build
 
+      - name: Compress database
+        run: gzip -kf src/data/snapshot/close-powerlifting.sqlite
+
       - name: Show database size
         run: ls -lh src/data/snapshot/
 
@@ -56,4 +59,4 @@ jobs:
           gh release create snapshot-latest \
             --title "OPL SQLite snapshot ($BUILT)" \
             --notes "Automated rebuild from the OpenPowerlifting bulk CSV. See the metadata table for counts." \
-            src/data/snapshot/close-powerlifting.sqlite
+            src/data/snapshot/close-powerlifting.sqlite.gz

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tmp/
 src/data/snapshot/*.json
 src/data/snapshot/*.bin
 src/data/snapshot/*.sqlite
+src/data/snapshot/*.sqlite.gz
 src/data/snapshot/*.sqlite-*
 src/data/snapshot/.tmp-*
 src/data/snapshot/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,13 @@ snapshot-publish:
 	}
 	@$(MAKE) snapshot-build
 	@BUILT=$$(node -e "const Database=require('better-sqlite3'); const db=new Database('src/data/snapshot/close-powerlifting.sqlite',{readonly:true}); console.log(db.prepare(\"SELECT value FROM metadata WHERE key = 'built_at'\").get().value); db.close();"); \
+	gzip -kf src/data/snapshot/close-powerlifting.sqlite; \
 	echo "Publishing snapshot-latest release..."; \
 	gh release delete $(SNAPSHOT_TAG) --yes --cleanup-tag 2>/dev/null || true; \
 	gh release create $(SNAPSHOT_TAG) \
 		--title "OPL SQLite snapshot ($$BUILT)" \
 		--notes "Manual publish via Makefile. See the metadata table for counts." \
-		src/data/snapshot/close-powerlifting.sqlite
+		src/data/snapshot/close-powerlifting.sqlite.gz
 
 # === Deployment ===
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ Fetch the latest pre-built SQLite snapshot from the GitHub Release:
 npm run snapshot:download
 ```
 
-This drops `close-powerlifting.sqlite` into `src/data/snapshot/`. The server opens this database at boot — without it, `npm run dev` will refuse to start.
+This downloads the compressed release asset and expands `close-powerlifting.sqlite` into `src/data/snapshot/`. The server opens this database at boot — without it, `npm run dev` will refuse to start.
 
 ## Environment Variables
 
@@ -72,7 +72,7 @@ The HTTP server starts immediately but `GET /healthz` returns 503 until the SQLi
 
 ## Snapshot
 
-The OPL dataset is rebuilt weekly by `.github/workflows/update-data.yml` and published as a GitHub Release (`snapshot-latest`). The Dockerfile downloads the SQLite asset at image-build time, so production containers ship with the data baked in.
+The OPL dataset is rebuilt weekly by `.github/workflows/update-data.yml` and published as a compressed GitHub Release asset (`snapshot-latest`). The Dockerfile downloads and expands the SQLite asset at image-build time, so production containers ship with the data baked in.
 
 | Task                          | Command                     | Notes                                                                           |
 | ----------------------------- | --------------------------- | ------------------------------------------------------------------------------- |

--- a/scripts/download-snapshot.ts
+++ b/scripts/download-snapshot.ts
@@ -6,9 +6,11 @@ import Database from "better-sqlite3";
 import fs from "node:fs";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 
 import { buildDatabase } from "../src/data/database-builder";
 import {
+  DATABASE_ARCHIVE_FILE_NAME,
   DATABASE_FILE,
   DATABASE_FILE_NAME,
   DATABASE_SCHEMA_VERSION,
@@ -30,6 +32,42 @@ async function main(): Promise<void> {
   await fs.promises.mkdir(SNAPSHOT_DIR, { recursive: true });
 
   logger.info(`download-snapshot: source ${BASE_URL}`);
+  logger.info(`download-snapshot: fetching ${DATABASE_ARCHIVE_FILE_NAME}`);
+  try {
+    await downloadCompressedTo(`${BASE_URL}/${DATABASE_ARCHIVE_FILE_NAME}`, DATABASE_FILE);
+    assertSupportedSchema(DATABASE_FILE);
+    logger.info(`download-snapshot: wrote ${DATABASE_FILE_NAME} (${humanSize(DATABASE_FILE)})`);
+  } catch (error) {
+    await fs.promises.rm(DATABASE_FILE, { force: true });
+    logger.warn(
+      "download-snapshot: compressed SQLite snapshot unavailable; trying raw asset",
+      error,
+    );
+    await downloadRawOrBuild();
+  }
+}
+
+async function downloadTo(url: string, dest: string): Promise<void> {
+  const response = await fetch(url, { redirect: "follow" });
+  if (!response.ok || response.body == null) {
+    throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  }
+  await pipeline(Readable.fromWeb(response.body as never), fs.createWriteStream(dest));
+}
+
+async function downloadCompressedTo(url: string, dest: string): Promise<void> {
+  const response = await fetch(url, { redirect: "follow" });
+  if (!response.ok || response.body == null) {
+    throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+  }
+  await pipeline(
+    Readable.fromWeb(response.body as never),
+    createGunzip(),
+    fs.createWriteStream(dest),
+  );
+}
+
+async function downloadRawOrBuild(): Promise<void> {
   logger.info(`download-snapshot: fetching ${DATABASE_FILE_NAME}`);
   try {
     await downloadTo(`${BASE_URL}/${DATABASE_FILE_NAME}`, DATABASE_FILE);
@@ -43,14 +81,6 @@ async function main(): Promise<void> {
     );
     await buildDatabase(logger);
   }
-}
-
-async function downloadTo(url: string, dest: string): Promise<void> {
-  const response = await fetch(url, { redirect: "follow" });
-  if (!response.ok || response.body == null) {
-    throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
-  }
-  await pipeline(Readable.fromWeb(response.body as never), fs.createWriteStream(dest));
 }
 
 function assertSupportedSchema(file: string): void {

--- a/src/data/database-builder.ts
+++ b/src/data/database-builder.ts
@@ -350,9 +350,7 @@ function entryValues(entry: Omit<Entry, "lifterId" | "meetId">, lifterId: number
 
 function createIndexes(db: DatabaseType): void {
   db.exec(`
-    CREATE INDEX idx_lifters_username ON lifters(username);
     CREATE INDEX idx_lifters_name ON lifters(name);
-    CREATE INDEX idx_meets_path ON meets(path);
     CREATE INDEX idx_meets_federation_slug ON meets(federation_slug);
     CREATE INDEX idx_meets_date ON meets(date);
     CREATE INDEX idx_entries_lifter_id ON entries(lifter_id);

--- a/src/data/database-files.ts
+++ b/src/data/database-files.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
 export const DATABASE_FILE_NAME = "close-powerlifting.sqlite";
-export const DATABASE_SCHEMA_VERSION = 2;
+export const DATABASE_SCHEMA_VERSION = 3;
 export const SNAPSHOT_DIR = path.join(__dirname, "snapshot");
 export const DATABASE_FILE = path.join(SNAPSHOT_DIR, DATABASE_FILE_NAME);

--- a/src/data/database-files.ts
+++ b/src/data/database-files.ts
@@ -1,6 +1,24 @@
+import fs from "node:fs";
 import path from "node:path";
 
 export const DATABASE_FILE_NAME = "close-powerlifting.sqlite";
+export const DATABASE_ARCHIVE_FILE_NAME = `${DATABASE_FILE_NAME}.gz`;
 export const DATABASE_SCHEMA_VERSION = 3;
-export const SNAPSHOT_DIR = path.join(__dirname, "snapshot");
+export const SNAPSHOT_DIR = resolveSnapshotDir();
 export const DATABASE_FILE = path.join(SNAPSHOT_DIR, DATABASE_FILE_NAME);
+
+function resolveSnapshotDir(): string {
+  const compiledSnapshotDir = path.join(__dirname, "snapshot");
+  if (hasSnapshot(compiledSnapshotDir)) return compiledSnapshotDir;
+
+  const sourceSnapshotDir = path.join(process.cwd(), "src", "data", "snapshot");
+  if (sourceSnapshotDir !== compiledSnapshotDir && hasSnapshot(sourceSnapshotDir)) {
+    return sourceSnapshotDir;
+  }
+
+  return compiledSnapshotDir;
+}
+
+function hasSnapshot(snapshotDir: string): boolean {
+  return fs.existsSync(path.join(snapshotDir, DATABASE_FILE_NAME));
+}

--- a/src/data/materialized-tables.ts
+++ b/src/data/materialized-tables.ts
@@ -23,7 +23,9 @@ interface CountRow {
 
 export function createDerivedTables(db: DatabaseType): void {
   createFederationsTable(db);
+  createLifterSearchTable(db);
   createLifterBestsTable(db);
+  createMetricCountsTable(db);
   createRankingFilterBestsTable(db);
   createRecordsTable(db);
 }
@@ -88,6 +90,33 @@ function createLifterBestsTable(db: DatabaseType): void {
   db.exec(`
     CREATE UNIQUE INDEX idx_lifter_bests_metric_rank ON lifter_bests(metric, rank);
     CREATE INDEX idx_lifter_bests_lifter ON lifter_bests(lifter_id);
+  `);
+}
+
+function createLifterSearchTable(db: DatabaseType): void {
+  db.exec(`
+    CREATE VIRTUAL TABLE lifter_search USING fts5(
+      username,
+      name,
+      content='lifters',
+      content_rowid='id',
+      tokenize='trigram'
+    );
+
+    INSERT INTO lifter_search(rowid, username, name)
+    SELECT id, username, name
+    FROM lifters;
+  `);
+}
+
+function createMetricCountsTable(db: DatabaseType): void {
+  db.exec(`
+    CREATE TABLE metric_counts AS
+    SELECT metric, COUNT(*) AS count
+    FROM lifter_bests
+    GROUP BY metric;
+
+    CREATE UNIQUE INDEX idx_metric_counts_metric ON metric_counts(metric);
   `);
 }
 

--- a/src/data/materialized-tables.ts
+++ b/src/data/materialized-tables.ts
@@ -126,6 +126,8 @@ function createRankingFilterBestsTable(db: DatabaseType): void {
       metric TEXT NOT NULL,
       equipment_key TEXT NOT NULL,
       sex_key TEXT NOT NULL,
+      weight_class_kg REAL,
+      age_class TEXT,
       entry_id INTEGER NOT NULL,
       rank INTEGER NOT NULL
     );
@@ -136,7 +138,7 @@ function createRankingFilterBestsTable(db: DatabaseType): void {
 
   db.exec(`
     CREATE UNIQUE INDEX idx_ranking_filter_bests_lookup
-      ON ranking_filter_bests(metric, equipment_key, sex_key, rank);
+      ON ranking_filter_bests(metric, equipment_key, sex_key, weight_class_kg, age_class, rank);
   `);
 }
 
@@ -156,7 +158,9 @@ function insertRankingFilterBests(db: DatabaseType, metric: RankingMetricDefinit
   }
 
   db.prepare(`
-    INSERT INTO ranking_filter_bests (metric, equipment_key, sex_key, entry_id, rank)
+    INSERT INTO ranking_filter_bests (
+      metric, equipment_key, sex_key, weight_class_kg, age_class, entry_id, rank
+    )
     WITH equipment_entries AS (
       ${equipmentSelects.join("\nUNION ALL\n")}
     ),
@@ -164,6 +168,8 @@ function insertRankingFilterBests(db: DatabaseType, metric: RankingMetricDefinit
       SELECT
         equipment_key,
         'all' AS sex_key,
+        NULL AS weight_class_kg,
+        NULL AS age_class,
         entry_id,
         lifter_id,
         value
@@ -172,21 +178,71 @@ function insertRankingFilterBests(db: DatabaseType, metric: RankingMetricDefinit
       SELECT
         equipment_key,
         CASE sex WHEN 'M' THEN 'men' ELSE 'women' END AS sex_key,
+        NULL AS weight_class_kg,
+        NULL AS age_class,
         entry_id,
         lifter_id,
         value
       FROM equipment_entries
       WHERE sex IN ('M', 'F')
+      UNION ALL
+      SELECT
+        equipment_key,
+        'all' AS sex_key,
+        weight_class_kg,
+        NULL AS age_class,
+        entry_id,
+        lifter_id,
+        value
+      FROM equipment_entries
+      WHERE weight_class_kg IS NOT NULL
+      UNION ALL
+      SELECT
+        equipment_key,
+        CASE sex WHEN 'M' THEN 'men' ELSE 'women' END AS sex_key,
+        weight_class_kg,
+        NULL AS age_class,
+        entry_id,
+        lifter_id,
+        value
+      FROM equipment_entries
+      WHERE sex IN ('M', 'F')
+        AND weight_class_kg IS NOT NULL
+      UNION ALL
+      SELECT
+        equipment_key,
+        'all' AS sex_key,
+        NULL AS weight_class_kg,
+        age_class,
+        entry_id,
+        lifter_id,
+        value
+      FROM equipment_entries
+      WHERE age_class IS NOT NULL
+      UNION ALL
+      SELECT
+        equipment_key,
+        CASE sex WHEN 'M' THEN 'men' ELSE 'women' END AS sex_key,
+        NULL AS weight_class_kg,
+        age_class,
+        entry_id,
+        lifter_id,
+        value
+      FROM equipment_entries
+      WHERE sex IN ('M', 'F')
+        AND age_class IS NOT NULL
     ),
     best AS (
       SELECT
         equipment_key,
         sex_key,
+        weight_class_kg,
+        age_class,
         entry_id,
         lifter_id,
         value,
         ROW_NUMBER() OVER (
-          PARTITION BY equipment_key, sex_key, lifter_id
+          PARTITION BY equipment_key, sex_key, weight_class_kg, age_class, lifter_id
           ORDER BY value DESC, entry_id ASC
         ) AS lifter_rank
       FROM candidates
@@ -195,15 +251,17 @@ function insertRankingFilterBests(db: DatabaseType, metric: RankingMetricDefinit
       SELECT
         equipment_key,
         sex_key,
+        weight_class_kg,
+        age_class,
         entry_id,
         ROW_NUMBER() OVER (
-          PARTITION BY equipment_key, sex_key
+          PARTITION BY equipment_key, sex_key, weight_class_kg, age_class
           ORDER BY value DESC, entry_id ASC
         ) AS rank
       FROM best
       WHERE lifter_rank = 1
     )
-    SELECT ?, equipment_key, sex_key, entry_id, rank
+    SELECT ?, equipment_key, sex_key, weight_class_kg, age_class, entry_id, rank
     FROM ranked
   `).run(...bindings, metric.metric);
 }
@@ -219,6 +277,8 @@ function rankingEquipmentSelect(
       id AS entry_id,
       lifter_id,
       sex,
+      weight_class_kg,
+      age_class,
       ${metric.field} AS value
     FROM entries
     WHERE ${metric.field} IS NOT NULL

--- a/src/routes/api/health-check/route-status.service.test.ts
+++ b/src/routes/api/health-check/route-status.service.test.ts
@@ -60,12 +60,23 @@ describe("route status service", () => {
     expect(urls).not.toContain("/api/rankings/filter/raw/men");
     expect(urls).not.toContain("/api/records?age_class=40-44");
   });
+
+  it("caps cached response bodies", async () => {
+    stubFetch(undefined, "x".repeat(10_000));
+
+    refreshRouteStatusesInBackground("http://127.0.0.1");
+    const groups = await waitForRouteGroups();
+    const body = groups[0]?.routes[0]?.body;
+
+    expect(body).toContain("[truncated]");
+    expect(body?.length).toBeLessThan(2_100);
+  });
 });
 
-function stubFetch(onRequest?: () => void): void {
+function stubFetch(onRequest?: () => void, body?: string): void {
   globalThis.fetch = async (input) => {
     onRequest?.();
-    return new Response(JSON.stringify({ ok: true, path: fetchInputUrl(input) }), {
+    return new Response(body ?? JSON.stringify({ ok: true, path: fetchInputUrl(input) }), {
       headers: {
         "content-type": "application/json",
         date: new Date().toUTCString(),

--- a/src/routes/api/health-check/route-status.service.ts
+++ b/src/routes/api/health-check/route-status.service.ts
@@ -29,6 +29,7 @@ const FETCH_TIMEOUT_MS = 10_000;
 // Cache TTL for the route status payload. The /status HTML page only renders
 // the last cached snapshot and refreshes it in the background.
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MAX_STATUS_BODY_LENGTH = 2_048;
 
 // Ordered list of every API endpoint we surface on /status. Grouped so the
 // HTML page can render sticky headers per tag. Variations of the same
@@ -124,11 +125,14 @@ async function probeRoute(baseUrl: string, path: string): Promise<RouteStatus> {
 
 function formatBody(body: string): string | null {
   if (body.length === 0) return null;
+  let formatted: string;
   try {
-    return JSON.stringify(JSON.parse(body), null, 2);
+    formatted = JSON.stringify(JSON.parse(body), null, 2);
   } catch {
-    return body;
+    formatted = body;
   }
+  if (formatted.length <= MAX_STATUS_BODY_LENGTH) return formatted;
+  return `${formatted.slice(0, MAX_STATUS_BODY_LENGTH)}\n... [truncated]`;
 }
 
 async function refreshRouteStatuses(baseUrl: string): Promise<RouteGroup[]> {

--- a/src/routes/api/rankings/rankings.service.test.ts
+++ b/src/routes/api/rankings/rankings.service.test.ts
@@ -46,6 +46,24 @@ describe("rankings service", () => {
       expect(usernames).not.toContain("johnsmith1");
     });
 
+    it("filters precomputed rankings by weight class", async () => {
+      const { data } = await service().getFilteredRankings(
+        { equipment: "raw", sex: "men", weight_class: "100" },
+        { units: "kg" },
+      );
+      const usernames = data.map((r) => (r as { username: string }).username);
+      expect(usernames).toEqual(["edcoan"]);
+    });
+
+    it("filters precomputed rankings by age class", async () => {
+      const { data } = await service().getFilteredRankings(
+        { equipment: "raw", sex: "men" },
+        { age_class: "24-34", units: "kg" },
+      );
+      const usernames = data.map((r) => (r as { username: string }).username);
+      expect(usernames).toEqual(["edcoan", "marisrazmanis"]);
+    });
+
     it("supports custom sort metric on the deepest filter", async () => {
       const { data } = await service().getFilteredRankings(
         {

--- a/src/routes/api/rankings/rankings.service.ts
+++ b/src/routes/api/rankings/rankings.service.ts
@@ -253,11 +253,10 @@ function canUsePrecomputedFilter(metric: RankMetric, filter: RankingFilter): boo
   return (
     metric === PRECOMPUTED_RANKING_METRIC &&
     filter.equipmentKey != null &&
-    filter.weightClassKg == null &&
     filter.yearPrefix == null &&
     filter.eventValues == null &&
-    filter.ageClass == null &&
-    filter.federation == null
+    filter.federation == null &&
+    !(filter.weightClassKg != null && filter.ageClass != null)
   );
 }
 
@@ -271,6 +270,7 @@ async function countPrecomputedFilteredRanking(
     .where("metric", metric)
     .where("equipment_key", filter.equipmentKey)
     .where("sex_key", filter.sexKey ?? "all")
+    .modify((query) => applyPrecomputedDimensionFilter(query, filter))
     .count({ count: "*" })
     .first();
   return Number(row?.count ?? 0);
@@ -290,6 +290,7 @@ async function selectPrecomputedFilteredRanking(
     .where("rb.metric", metric)
     .where("rb.equipment_key", filter.equipmentKey)
     .where("rb.sex_key", filter.sexKey ?? "all")
+    .modify((query) => applyPrecomputedDimensionFilter(query, filter, "rb"))
     .orderBy("rb.rank", "asc")
     .limit(pagination.per_page)
     .offset(pagination.from > 0 ? pagination.from - 1 : 0)
@@ -317,6 +318,25 @@ async function selectPrecomputedFilteredRanking(
       meet_date: "m.date",
       lifter_country: "e.lifter_country",
     });
+}
+
+function applyPrecomputedDimensionFilter(
+  query: Knex.QueryBuilder,
+  filter: RankingFilter,
+  alias?: string,
+): void {
+  const prefix = alias == null ? "" : `${alias}.`;
+  if (filter.weightClassKg == null) {
+    query.whereNull(`${prefix}weight_class_kg`);
+  } else {
+    query.where(`${prefix}weight_class_kg`, filter.weightClassKg);
+  }
+
+  if (filter.ageClass == null) {
+    query.whereNull(`${prefix}age_class`);
+  } else {
+    query.where(`${prefix}age_class`, filter.ageClass);
+  }
 }
 
 async function countFilteredRanking(

--- a/src/routes/api/users/users.service.ts
+++ b/src/routes/api/users/users.service.ts
@@ -8,6 +8,7 @@ import { configuration } from "../../../configuration";
 import type { GetCompareType, GetUserQueryType, GetUsersType } from "./users.schema";
 
 const { defaultPerPage } = configuration.pagination;
+const MIN_FTS_SEARCH_LENGTH = 3;
 
 interface LifterRow {
   id: number;
@@ -68,6 +69,15 @@ interface RankCountRow {
   count: string | number;
 }
 
+interface LifterSearchCountRow {
+  count: string | number;
+}
+
+interface LifterSearchRow {
+  username: string;
+  name: string;
+}
+
 export function createUsersService(store: DataStoreType) {
   async function listLifters(query: GetUsersType): Promise<{
     data: { username: string; name: string }[];
@@ -75,13 +85,18 @@ export function createUsersService(store: DataStoreType) {
   }> {
     const { db } = store.get();
     const needle = query.search?.trim() ?? "";
+    const currentPage = query.current_page ?? 1;
+    const perPage = query.per_page ?? defaultPerPage;
+
+    if (needle.length >= MIN_FTS_SEARCH_LENGTH) {
+      return searchLifters(db, needle, currentPage, perPage);
+    }
+
     const base = db<LifterRow>("lifters");
     applyLifterSearch(base, needle);
 
     const totalRow = await base.clone().count({ count: "*" }).first();
     const total = Number(totalRow?.count ?? 0);
-    const currentPage = query.current_page ?? 1;
-    const perPage = query.per_page ?? defaultPerPage;
     const pagination = buildPagination(total, currentPage, perPage);
     const rows = await base
       .clone()
@@ -207,10 +222,7 @@ export function createUsersService(store: DataStoreType) {
     const rankRows = await db<RankRow>("lifter_bests")
       .where("lifter_id", lifter.id)
       .select("metric", "rank");
-    const countRows = await db<RankCountRow>("lifter_bests")
-      .select("metric")
-      .count({ count: "*" })
-      .groupBy("metric");
+    const countRows = await db<RankCountRow>("metric_counts").select("metric", "count");
 
     const rankByMetric = new Map(rankRows.map((row) => [row.metric, row.rank]));
     const outOfByMetric = new Map(
@@ -271,6 +283,49 @@ function applyLifterSearch(query: Knex.QueryBuilder<LifterRow>, needle: string):
   query.where(function applySearch() {
     this.where("username", "like", pattern).orWhere("name", "like", pattern);
   });
+}
+
+async function searchLifters(
+  db: Knex,
+  needle: string,
+  currentPage: number,
+  perPage: number,
+): Promise<{
+  data: { username: string; name: string }[];
+  pagination: Pagination;
+}> {
+  const search = ftsPhrase(needle);
+  const countRows = await db.raw<LifterSearchCountRow[]>(
+    `
+      SELECT COUNT(*) AS count
+      FROM lifter_search
+      WHERE lifter_search MATCH ?
+    `,
+    [search],
+  );
+  const total = Number(countRows[0]?.count ?? 0);
+  const pagination = buildPagination(total, currentPage, perPage);
+  const rows = await db.raw<LifterSearchRow[]>(
+    `
+      SELECT l.username, l.name
+      FROM lifter_search
+      JOIN lifters AS l ON l.id = lifter_search.rowid
+      WHERE lifter_search MATCH ?
+      ORDER BY l.name ASC
+      LIMIT ?
+      OFFSET ?
+    `,
+    [search, pagination.per_page, pagination.from > 0 ? pagination.from - 1 : 0],
+  );
+
+  return {
+    data: rows.map((row) => ({ username: row.username, name: row.name })),
+    pagination,
+  };
+}
+
+function ftsPhrase(needle: string): string {
+  return `"${needle.replaceAll('"', '""')}"`;
 }
 
 async function getLifterByUsername(db: Knex, username: string): Promise<LifterRow | null> {


### PR DESCRIPTION
## Summary
- cap cached status probe bodies so /status stays small
- precompute lifter FTS search, metric counts, and narrow DOTS ranking filters
- publish/download the SQLite snapshot as gzip while keeping raw SQLite on disk
- let local production builds find src/data/snapshot when dist has no copied DB

## Test Plan
- npm run check
- npm test
- npm run build