### PR TITLE
fix(ci): deploy published database snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+  workflow_call:
+    inputs:
+      snapshot_refresh:
+        description: Rebuild and deploy after publishing a new database snapshot
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -68,7 +75,9 @@ jobs:
     needs: [check, test]
     name: Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >
+      (github.event_name == 'push' || inputs.snapshot_refresh) &&
+      github.ref == 'refs/heads/main'
     outputs:
       tag: ${{ steps.image-name.outputs.TAG }}
 
@@ -88,11 +97,18 @@ jobs:
 
       - name: Generate Image Name
         id: image-name
+        env:
+          SNAPSHOT_REFRESH: ${{ inputs.snapshot_refresh }}
         run: |
-          TAG=$(echo ${{ github.sha }} | cut -c1-7)
-          IMAGE_URL=$(echo ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:$TAG | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_URL=$IMAGE_URL" >> $GITHUB_OUTPUT
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [[ "$SNAPSHOT_REFRESH" == "true" ]]; then
+            TAG="${SHORT_SHA}-snapshot-${GITHUB_RUN_ID}"
+          else
+            TAG="$SHORT_SHA"
+          fi
+          IMAGE_URL=$(printf '%s' "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:$TAG" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_URL=$IMAGE_URL" >> "$GITHUB_OUTPUT"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker Image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -101,9 +117,12 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.image-name.outputs.IMAGE_URL }}
+          build-args: SNAPSHOT_CACHE_BUST=${{ github.run_id }}
 
   deploy:
-    if: github.event_name == 'push'
+    if: >
+      (github.event_name == 'push' || inputs.snapshot_refresh) &&
+      github.ref == 'refs/heads/main'
     needs: build
     name: Deploy
     uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@970a4d7bd568e096d091fbec3371019c763def1f # v0.0.26
@@ -139,11 +158,13 @@ jobs:
 
       - name: Generate Image Name
         id: image-name
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          TAG=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)
-          IMAGE_URL=$(echo ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:$TAG | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_URL=$IMAGE_URL" >> $GITHUB_OUTPUT
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+          TAG="${PR_HEAD_SHA::7}"
+          IMAGE_URL=$(printf '%s' "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:$TAG" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_URL=$IMAGE_URL" >> "$GITHUB_OUTPUT"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker Image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,10 +1,11 @@
 name: Update OPL Database
 
 # Re-parses OpenPowerlifting's nightly bulk CSV into our runtime SQLite
-# database and publishes it as a compressed asset on the `snapshot-latest` GitHub Release.
-# The Dockerfile fetches these assets at image-build time, so the
-# database lives entirely outside the git history — no LFS, no quota
-# pressure, no 700 MB blobs in the repo.
+# database, publishes it as a compressed asset on the `snapshot-latest`
+# GitHub Release, then triggers CI to rebuild and deploy the application.
+# The Dockerfile fetches the asset at image-build time, so the database lives
+# entirely outside the git history — no LFS, no quota pressure, no 700 MB
+# blobs in the repo.
 
 on:
   schedule:
@@ -60,3 +61,11 @@ jobs:
             --title "OPL SQLite snapshot ($BUILT)" \
             --notes "Automated rebuild from the OpenPowerlifting bulk CSV. See the metadata table for counts." \
             src/data/snapshot/close-powerlifting.sqlite.gz
+
+  deploy-snapshot:
+    name: Build and deploy published snapshot
+    needs: publish-snapshot
+    uses: ./.github/workflows/ci.yml
+    with:
+      snapshot_refresh: true
+    secrets: inherit

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -65,6 +65,8 @@ jobs:
   deploy-snapshot:
     name: Build and deploy published snapshot
     needs: publish-snapshot
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
     with:
       snapshot_refresh: true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ The HTTP server starts immediately but `GET /healthz` returns 503 until the SQLi
 
 ## Snapshot
 
-The OPL dataset is rebuilt weekly by `.github/workflows/update-data.yml` and published as a compressed GitHub Release asset (`snapshot-latest`). The Dockerfile downloads and expands the SQLite asset at image-build time, so production containers ship with the data baked in.
+The OPL dataset is rebuilt weekly by `.github/workflows/update-data.yml` and published as a compressed GitHub Release asset (`snapshot-latest`). After publishing, the workflow calls the reusable CI workflow to build and deploy a new image. The Docker build uses a per-run cache-bust value when downloading and expanding the SQLite asset, so production containers always ship with the newly published data baked in.
 
 | Task                          | Command                     | Notes                                                                           |
 | ----------------------------- | --------------------------- | ------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- make the existing CI workflow reusable for snapshot refreshes
- run that workflow only after `snapshot-latest` is published successfully
- rebuild with a per-run `SNAPSHOT_CACHE_BUST` value
- publish snapshot builds under a unique `<sha>-snapshot-<run-id>` image tag before deployment
- document the automatic rebuild and deployment flow

The reusable call keeps the update workflow running until deployment finishes, so a build or deployment failure is reported on the same workflow run.

## Verification

- `actionlint` 1.7.7
- `npm run check`
- `npm run test:ci` — 22 files, 141 tests passed