### PR TITLE
fix(deps): keep npm coupled to Node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,11 @@
   "skipInstalls": false,
   "constraints": {
     "node": ">=26.1.0",
-    "npm": "11.18.0"
+    "npm": "11.17.0"
   },
   "packageRules": [
     {
       "description": "Use the npm version bundled with the pinned Node.js release",
-      "matchManagers": ["npm"],
       "matchPackageNames": ["npm"],
       "enabled": false
     },


### PR DESCRIPTION
## Summary

- restore Renovate lockfile generation to npm `11.17.0`, matching Node.js 26.5.0
- apply the npm ignore policy across all Renovate managers, including `renovate-config` tool constraints

This prevents npm from being upgraded independently of the pinned Node.js runtime and supersedes #386.

## Verification

- `jq empty renovate.json`
- `renovate-config-validator renovate.json` using Renovate 43.243.0