### PR TITLE
fix(api): type OpenAPI response schemas

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -86,7 +86,7 @@ export function createApp(context: AppContext): HonoApp {
 
   app.route("/", createMainRouter(context));
 
-  app.doc("/docs/api.json", {
+  app.doc31("/docs/api.json", {
     openapi: "3.1.0",
     info: {
       title: "close-powerlifting API",

--- a/src/routes/api/api.schemas.test.ts
+++ b/src/routes/api/api.schemas.test.ts
@@ -1,3 +1,4 @@
+import { z } from "@hono/zod-openapi";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { createApp } from "../../app";
@@ -20,6 +21,19 @@ let app: ReturnType<typeof createApp>;
 beforeEach(() => {
   app = createApp(createTestContext());
 });
+
+function expectExactSchemaMatch(schema: z.ZodType, payload: unknown) {
+  const result = schema.safeParse(payload);
+  expect(result.success).toBe(true);
+  if (!result.success) return;
+  expect(result.data).toStrictEqual(payload);
+}
+
+function containsLegacyNullable(value: unknown): boolean {
+  if (value == null || typeof value !== "object") return false;
+  if ("nullable" in value) return true;
+  return Object.values(value).some(containsLegacyNullable);
+}
 
 describe("OpenAPI response schemas", () => {
   it("publishes concrete component definitions for every feature response", async () => {
@@ -53,6 +67,7 @@ describe("OpenAPI response schemas", () => {
 
     expect(schemas.UserListData.items.type).toBe("object");
     expect(schemas.CompetitionResult.properties.place.anyOf).toContainEqual({ type: "null" });
+    expect(containsLegacyNullable(spec)).toBe(false);
   });
 
   it("documents pagination on the users list response", async () => {
@@ -97,19 +112,38 @@ describe("OpenAPI response schemas", () => {
       app.request("/api/federations/wrpf"),
     ]);
 
-    expect(RankingEntry.safeParse((await ranking.json()).data).success).toBe(true);
-    expect(RecordsData.safeParse((await records.json()).data).success).toBe(true);
-    expect(UserListData.safeParse((await users.json()).data).success).toBe(true);
-    expect(CompareData.safeParse((await comparison.json()).data).success).toBe(true);
-    expect(Progression.safeParse((await progression.json()).data).success).toBe(true);
-    expect(PersonalBests.safeParse((await personalBests.json()).data).success).toBe(true);
-    expect(UserRank.safeParse((await userRank.json()).data).success).toBe(true);
-    expect(UserProfile.safeParse((await userProfile.json()).data).success).toBe(true);
-    expect(MeetSummary.safeParse((await meets.json()).data[0]).success).toBe(true);
-    expect(MeetHighlights.safeParse((await meetHighlights.json()).data).success).toBe(true);
-    expect(MeetDetail.safeParse((await meetDetail.json()).data).success).toBe(true);
-    expect(FederationRow.safeParse((await federations.json()).data[0]).success).toBe(true);
-    expect(FederationStats.safeParse((await federationStats.json()).data).success).toBe(true);
-    expect(FederationDetail.safeParse((await federationDetail.json()).data).success).toBe(true);
+    for (const response of [
+      ranking,
+      records,
+      users,
+      comparison,
+      progression,
+      personalBests,
+      userRank,
+      userProfile,
+      meets,
+      meetHighlights,
+      meetDetail,
+      federations,
+      federationStats,
+      federationDetail,
+    ]) {
+      expect(response.status).toBe(200);
+    }
+
+    expectExactSchemaMatch(RankingEntry, (await ranking.json()).data);
+    expectExactSchemaMatch(RecordsData, (await records.json()).data);
+    expectExactSchemaMatch(UserListData, (await users.json()).data);
+    expectExactSchemaMatch(CompareData, (await comparison.json()).data);
+    expectExactSchemaMatch(Progression, (await progression.json()).data);
+    expectExactSchemaMatch(PersonalBests, (await personalBests.json()).data);
+    expectExactSchemaMatch(UserRank, (await userRank.json()).data);
+    expectExactSchemaMatch(UserProfile, (await userProfile.json()).data);
+    expectExactSchemaMatch(MeetSummary, (await meets.json()).data[0]);
+    expectExactSchemaMatch(MeetHighlights, (await meetHighlights.json()).data);
+    expectExactSchemaMatch(MeetDetail, (await meetDetail.json()).data);
+    expectExactSchemaMatch(FederationRow, (await federations.json()).data[0]);
+    expectExactSchemaMatch(FederationStats, (await federationStats.json()).data);
+    expectExactSchemaMatch(FederationDetail, (await federationDetail.json()).data);
   });
 });

--- a/src/routes/api/api.schemas.test.ts
+++ b/src/routes/api/api.schemas.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { createApp } from "../../app";
+import { createTestContext } from "../../tests/fixtures";
+import { FederationDetail, FederationRow, FederationStats } from "./federations/federations.schema";
+import { MeetDetail, MeetHighlights, MeetSummary } from "./meets/meets.schema";
+import { RankingEntry } from "./rankings/rankings.schema";
+import { RecordsData } from "./records/records.schema";
+import {
+  CompareData,
+  PersonalBests,
+  Progression,
+  UserListData,
+  UserProfile,
+  UserRank,
+} from "./users/users.schema";
+
+let app: ReturnType<typeof createApp>;
+
+beforeEach(() => {
+  app = createApp(createTestContext());
+});
+
+describe("OpenAPI response schemas", () => {
+  it("publishes concrete component definitions for every feature response", async () => {
+    const res = await app.request("/docs/api.json");
+    expect(res.status).toBe(200);
+
+    const spec = await res.json();
+    const schemas = spec.components.schemas;
+    const responseSchemaNames = [
+      "RankingEntry",
+      "RecordsData",
+      "UserListData",
+      "CompareData",
+      "ProgressionData",
+      "PersonalBestsByEquipment",
+      "UserRank",
+      "UserProfile",
+      "MeetSummary",
+      "MeetHighlights",
+      "MeetDetail",
+      "FederationRow",
+      "FederationStats",
+      "FederationDetail",
+    ];
+
+    for (const name of responseSchemaNames) {
+      const schema = schemas[name];
+      expect(schema, `${name} should be registered`).toBeDefined();
+      expect(
+        schema.type ?? schema.allOf ?? schema.anyOf ?? schema.oneOf,
+        `${name} should not be an unconstrained schema`,
+      ).toBeDefined();
+    }
+  });
+
+  it("documents pagination on the users list response", async () => {
+    const res = await app.request("/docs/api.json");
+    const spec = await res.json();
+    const schema = spec.paths["/api/users"].get.responses["200"].content["application/json"].schema;
+
+    expect(schema.required).toContain("pagination");
+    expect(schema.properties.pagination.$ref).toBe("#/components/schemas/Pagination");
+  });
+
+  it("matches representative runtime payloads", async () => {
+    const [
+      ranking,
+      records,
+      users,
+      comparison,
+      progression,
+      personalBests,
+      userRank,
+      userProfile,
+      meets,
+      meetHighlights,
+      meetDetail,
+      federations,
+      federationStats,
+      federationDetail,
+    ] = await Promise.all([
+      app.request("/api/rankings/1"),
+      app.request("/api/records"),
+      app.request("/api/users"),
+      app.request("/api/users/compare?a=edcoan&b=johnsmith1&units=kg"),
+      app.request("/api/users/edcoan/progression?units=kg"),
+      app.request("/api/users/edcoan/personal-bests?units=kg"),
+      app.request("/api/users/edcoan/rank"),
+      app.request("/api/users/edcoan?units=kg&include_attempts=true"),
+      app.request("/api/meets"),
+      app.request("/api/meets/wrpf/2024-05-12/wrpfamericanpro/highlights?units=kg"),
+      app.request("/api/meets/wrpf/2024-05-12/wrpfamericanpro?units=kg"),
+      app.request("/api/federations"),
+      app.request("/api/federations/wrpf/stats"),
+      app.request("/api/federations/wrpf"),
+    ]);
+
+    expect(RankingEntry.safeParse((await ranking.json()).data).success).toBe(true);
+    expect(RecordsData.safeParse((await records.json()).data).success).toBe(true);
+    expect(UserListData.safeParse((await users.json()).data).success).toBe(true);
+    expect(CompareData.safeParse((await comparison.json()).data).success).toBe(true);
+    expect(Progression.safeParse((await progression.json()).data).success).toBe(true);
+    expect(PersonalBests.safeParse((await personalBests.json()).data).success).toBe(true);
+    expect(UserRank.safeParse((await userRank.json()).data).success).toBe(true);
+    expect(UserProfile.safeParse((await userProfile.json()).data).success).toBe(true);
+    expect(MeetSummary.safeParse((await meets.json()).data[0]).success).toBe(true);
+    expect(MeetHighlights.safeParse((await meetHighlights.json()).data).success).toBe(true);
+    expect(MeetDetail.safeParse((await meetDetail.json()).data).success).toBe(true);
+    expect(FederationRow.safeParse((await federations.json()).data[0]).success).toBe(true);
+    expect(FederationStats.safeParse((await federationStats.json()).data).success).toBe(true);
+    expect(FederationDetail.safeParse((await federationDetail.json()).data).success).toBe(true);
+  });
+});

--- a/src/routes/api/api.schemas.test.ts
+++ b/src/routes/api/api.schemas.test.ts
@@ -48,11 +48,11 @@ describe("OpenAPI response schemas", () => {
     for (const name of responseSchemaNames) {
       const schema = schemas[name];
       expect(schema, `${name} should be registered`).toBeDefined();
-      expect(
-        schema.type ?? schema.allOf ?? schema.anyOf ?? schema.oneOf,
-        `${name} should not be an unconstrained schema`,
-      ).toBeDefined();
+      expect(schema.type, `${name} should have a concrete top-level type`).toBeDefined();
     }
+
+    expect(schemas.UserListData.items.type).toBe("object");
+    expect(schemas.CompetitionResult.properties.place.anyOf).toContainEqual({ type: "null" });
   });
 
   it("documents pagination on the users list response", async () => {

--- a/src/routes/api/api.schemas.ts
+++ b/src/routes/api/api.schemas.ts
@@ -13,7 +13,15 @@ export const EquipmentSchema = z.enum([
   "Unlimited",
   "Straps",
 ]);
-export const PlaceSchema = z.union([z.number(), z.enum(["G", "DQ", "DD", "NS"])]).nullable();
+export const PlaceSchema = z
+  .union([z.number(), z.enum(["G", "DQ", "DD", "NS"]), z.null()])
+  .openapi({
+    anyOf: [
+      { type: "number" },
+      { type: "string", enum: ["G", "DQ", "DD", "NS"] },
+      { type: "null" },
+    ],
+  });
 
 export const PaginationSchema = z
   .object({

--- a/src/routes/api/api.schemas.ts
+++ b/src/routes/api/api.schemas.ts
@@ -1,9 +1,19 @@
 // Shared OpenAPI response shapes used across feature routes.
-// Keep these minimal — endpoint-specific data fields stay loosely typed
-// in the spec; consumers should rely on the published `docs/api.json`
-// for full field-level documentation.
 
 import { z } from "@hono/zod-openapi";
+
+export const UnitsSchema = z.enum(["lbs", "kg"]);
+export const SexSchema = z.enum(["M", "F", "Mx"]);
+export const EventSchema = z.enum(["SBD", "BD", "SD", "SB", "S", "B", "D"]);
+export const EquipmentSchema = z.enum([
+  "Raw",
+  "Wraps",
+  "Single-ply",
+  "Multi-ply",
+  "Unlimited",
+  "Straps",
+]);
+export const PlaceSchema = z.union([z.number(), z.enum(["G", "DQ", "DD", "NS"])]).nullable();
 
 export const PaginationSchema = z
   .object({
@@ -43,6 +53,16 @@ export function paginatedResponse<T extends z.ZodType>(dataSchema: T) {
     request_url: z.string(),
     message: z.string(),
     data: z.array(dataSchema),
+    pagination: PaginationSchema,
+  });
+}
+
+export function paginatedDataResponse<T extends z.ZodType>(dataSchema: T) {
+  return z.object({
+    status: z.literal("success"),
+    request_url: z.string(),
+    message: z.string(),
+    data: dataSchema,
     pagination: PaginationSchema,
   });
 }

--- a/src/routes/api/federations/federations.schema.ts
+++ b/src/routes/api/federations/federations.schema.ts
@@ -24,6 +24,42 @@ export type GetFederationsType = z.infer<typeof getFederationsValidation>;
 export type GetFederationsParamType = z.infer<typeof getFederationsParamValidation>;
 export type GetFederationMeetsQueryType = z.infer<typeof getFederationMeetsQueryValidation>;
 
-export const FederationRow = z.unknown().openapi("FederationRow");
-export const FederationDetail = z.unknown().openapi("FederationDetail");
-export const FederationStats = z.unknown().openapi("FederationStats");
+export const FederationRow = z
+  .object({
+    slug: z.string(),
+    code: z.string(),
+    parent_slug: z.string().nullable(),
+    meet_count: z.number(),
+  })
+  .openapi("FederationRow");
+
+const FederationMeet = z
+  .object({
+    path: z.string(),
+    meet_name: z.string(),
+    date: z.string(),
+    country: z.string().nullable(),
+    state: z.string().nullable(),
+    town: z.string().nullable(),
+    sanctioned: z.boolean(),
+  })
+  .openapi("FederationMeet");
+
+export const FederationDetail = FederationRow.extend({
+  meets: z.array(FederationMeet),
+}).openapi("FederationDetail");
+
+export const FederationStats = z
+  .object({
+    slug: z.string(),
+    code: z.string(),
+    parent_slug: z.string().nullable(),
+    total_meets: z.number(),
+    meets_by_year: z.array(
+      z.object({
+        year: z.number(),
+        meet_count: z.number(),
+      }),
+    ),
+  })
+  .openapi("FederationStats");

--- a/src/routes/api/federations/federations.schema.ts
+++ b/src/routes/api/federations/federations.schema.ts
@@ -24,14 +24,14 @@ export type GetFederationsType = z.infer<typeof getFederationsValidation>;
 export type GetFederationsParamType = z.infer<typeof getFederationsParamValidation>;
 export type GetFederationMeetsQueryType = z.infer<typeof getFederationMeetsQueryValidation>;
 
-export const FederationRow = z
-  .object({
-    slug: z.string(),
-    code: z.string(),
-    parent_slug: z.string().nullable(),
-    meet_count: z.number(),
-  })
-  .openapi("FederationRow");
+const FederationRowShape = {
+  slug: z.string(),
+  code: z.string(),
+  parent_slug: z.string().nullable(),
+  meet_count: z.number(),
+};
+
+export const FederationRow = z.object(FederationRowShape).openapi("FederationRow");
 
 const FederationMeet = z
   .object({
@@ -45,9 +45,12 @@ const FederationMeet = z
   })
   .openapi("FederationMeet");
 
-export const FederationDetail = FederationRow.extend({
-  meets: z.array(FederationMeet),
-}).openapi("FederationDetail");
+export const FederationDetail = z
+  .object({
+    ...FederationRowShape,
+    meets: z.array(FederationMeet),
+  })
+  .openapi("FederationDetail");
 
 export const FederationStats = z
   .object({

--- a/src/routes/api/meets/meets.schema.ts
+++ b/src/routes/api/meets/meets.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 
+import { EquipmentSchema, EventSchema, PlaceSchema, SexSchema, UnitsSchema } from "../api.schemas";
 import {
   currentPageValidation,
   federationSlugValidation,
@@ -43,6 +44,81 @@ export type GetMeetParamType = z.infer<typeof getMeetParamValidation>;
 export type GetMeetQueryType = z.infer<typeof getMeetQueryValidation>;
 export type GetMeetHighlightsQueryType = z.infer<typeof getMeetHighlightsQueryValidation>;
 
-export const MeetSummary = z.unknown().openapi("MeetSummary");
-export const MeetDetail = z.unknown().openapi("MeetDetail");
-export const MeetHighlights = z.unknown().openapi("MeetHighlights");
+const nullableNumber = z.number().nullable();
+
+const MeetLocation = {
+  country: z.string().nullable(),
+  state: z.string().nullable(),
+  town: z.string().nullable(),
+};
+
+export const MeetSummary = z
+  .object({
+    path: z.string(),
+    meet_name: z.string(),
+    federation: z.string(),
+    date: z.string(),
+    ...MeetLocation,
+    sanctioned: z.boolean(),
+  })
+  .openapi("MeetSummary");
+
+const MeetResult = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    sex: SexSchema.nullable(),
+    age: nullableNumber,
+    event: EventSchema,
+    equipment: EquipmentSchema,
+    weight_class_kg: nullableNumber,
+    bodyweight: nullableNumber,
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+    place: PlaceSchema,
+    units: UnitsSchema,
+  })
+  .openapi("MeetResult");
+
+const MeetHighlight = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    equipment: EquipmentSchema,
+    weight_class_kg: nullableNumber,
+    value: z.number(),
+  })
+  .nullable()
+  .openapi("MeetHighlight");
+
+export const MeetDetail = z
+  .object({
+    path: z.string(),
+    meet_name: z.string(),
+    federation: z.string(),
+    parent_federation: z.string().nullable(),
+    date: z.string(),
+    ...MeetLocation,
+    sanctioned: z.boolean(),
+    results: z.array(MeetResult),
+  })
+  .openapi("MeetDetail");
+
+export const MeetHighlights = z
+  .object({
+    path: z.string(),
+    meet_name: z.string(),
+    federation: z.string(),
+    date: z.string(),
+    highlights: z.object({
+      best_total: MeetHighlight,
+      best_squat: MeetHighlight,
+      best_bench: MeetHighlight,
+      best_deadlift: MeetHighlight,
+      best_dots: MeetHighlight,
+    }),
+  })
+  .openapi("MeetHighlights");

--- a/src/routes/api/rankings/rankings.schema.ts
+++ b/src/routes/api/rankings/rankings.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 
+import { EquipmentSchema, EventSchema, SexSchema, UnitsSchema } from "../api.schemas";
 import {
   currentPageValidation,
   federationSlugValidation,
@@ -75,4 +76,32 @@ export type GetFilteredRankingsQueryType = z.infer<typeof getFilteredRankingsQue
 export type GetFilteredRankingsParamType = z.infer<typeof getFilteredRankingsParamValidation>;
 export type GetRankType = z.infer<typeof getRankValidation>;
 
-export const RankingEntry = z.unknown().openapi("RankingEntry");
+const nullableNumber = z.number().nullable();
+
+export const RankingEntry = z
+  .object({
+    rank: z.number(),
+    username: z.string(),
+    name: z.string(),
+    sex: SexSchema.nullable(),
+    age: nullableNumber,
+    bodyweight: nullableNumber,
+    weight_class_kg: nullableNumber,
+    equipment: EquipmentSchema,
+    event: EventSchema,
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+    wilks: nullableNumber,
+    glossbrenner: nullableNumber,
+    goodlift: nullableNumber,
+    federation: z.string(),
+    meet_path: z.string(),
+    meet_name: z.string(),
+    meet_date: z.string(),
+    country: z.string().nullable(),
+    units: UnitsSchema,
+  })
+  .openapi("RankingEntry");

--- a/src/routes/api/records/records.schema.ts
+++ b/src/routes/api/records/records.schema.ts
@@ -64,4 +64,56 @@ export const getRecordsByWeightClassSexParamValidation = z.object({
 
 export type GetRecordsQueryType = z.infer<typeof getRecordsQueryValidation>;
 
-export const RecordsData = z.unknown().openapi("RecordsData");
+const equipmentGroupEnum = z.enum(["raw", "wraps", "single", "multi", "unlimited", "all-tested"]);
+const recordCategoryEnum = z.enum([
+  "squat_full_power",
+  "squat_all_events",
+  "bench_full_power",
+  "bench_all_events",
+  "deadlift_full_power",
+  "deadlift_all_events",
+  "total",
+]);
+const recordSexEnum = z.enum(["M", "F"]);
+
+const RecordEntry = z
+  .object({
+    weight_class_kg: z.number(),
+    rank: z.number(),
+    lift_value: z.number(),
+    username: z.string(),
+    name: z.string(),
+    federation: z.string(),
+    meet_path: z.string(),
+    meet_name: z.string(),
+    date: z.string(),
+  })
+  .openapi("RecordEntry");
+
+const RecordSection = z
+  .object({
+    sex: recordSexEnum,
+    equipment_group: equipmentGroupEnum,
+    records: z.array(RecordEntry),
+  })
+  .openapi("RecordSection");
+
+const RecordCategory = z
+  .object({
+    key: recordCategoryEnum,
+    title: z.string(),
+    sections: z.array(RecordSection),
+  })
+  .openapi("RecordCategory");
+
+export const RecordsData = z
+  .object({
+    filters: z.object({
+      equipment_group: equipmentGroupEnum.nullable(),
+      sex: recordSexEnum.nullable(),
+      weight_class_kg: z.number().nullable(),
+      age_class: z.string().nullable(),
+    }),
+    categories: z.array(RecordCategory),
+  })
+  .openapi("RecordsData");

--- a/src/routes/api/users/users.schema.ts
+++ b/src/routes/api/users/users.schema.ts
@@ -42,12 +42,10 @@ export type GetCompareType = z.infer<typeof getCompareValidation>;
 
 const nullableNumber = z.number().nullable();
 
-const LifterMatch = z
-  .object({
-    username: z.string(),
-    name: z.string(),
-  })
-  .openapi("LifterMatch");
+const LifterMatchShape = {
+  username: z.string(),
+  name: z.string(),
+};
 
 const PersonalBest = z
   .object({
@@ -61,16 +59,16 @@ const PersonalBest = z
   })
   .openapi("PersonalBest");
 
-const ProfileSummary = z
-  .object({
-    username: z.string(),
-    name: z.string(),
-    total_entries: z.number(),
-    first_meet: z.string().nullable(),
-    last_meet: z.string().nullable(),
-    personal_best: PersonalBest,
-  })
-  .openapi("ProfileSummary");
+const ProfileSummaryShape = {
+  username: z.string(),
+  name: z.string(),
+  total_entries: z.number(),
+  first_meet: z.string().nullable(),
+  last_meet: z.string().nullable(),
+  personal_best: PersonalBest,
+};
+
+const ProfileSummary = z.object(ProfileSummaryShape).openapi("ProfileSummary");
 
 const Attempts = z
   .object({
@@ -163,11 +161,14 @@ const Deltas = z
   })
   .openapi("Deltas");
 
-export const UserListData = z.array(LifterMatch).openapi("UserListData");
+export const UserListData = z.array(z.object(LifterMatchShape)).openapi("UserListData");
 
-export const UserProfile = ProfileSummary.extend({
-  competition_results: z.array(CompetitionResult),
-}).openapi("UserProfile");
+export const UserProfile = z
+  .object({
+    ...ProfileSummaryShape,
+    competition_results: z.array(CompetitionResult),
+  })
+  .openapi("UserProfile");
 
 export const PersonalBests = z
   .object({

--- a/src/routes/api/users/users.schema.ts
+++ b/src/routes/api/users/users.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 
+import { EquipmentSchema, EventSchema, PlaceSchema, UnitsSchema } from "../api.schemas";
 import { currentPageValidation, perPageValidation } from "../query.validation";
 
 const usernameSlug = z
@@ -39,9 +40,171 @@ export type GetUserParamType = z.infer<typeof getUserParamValidation>;
 export type GetUserQueryType = z.infer<typeof getUserQueryValidation>;
 export type GetCompareType = z.infer<typeof getCompareValidation>;
 
-export const UserListData = z.unknown().openapi("UserListData");
-export const UserProfile = z.unknown().openapi("UserProfile");
-export const PersonalBests = z.unknown().openapi("PersonalBestsByEquipment");
-export const Progression = z.unknown().openapi("ProgressionData");
-export const UserRank = z.unknown().openapi("UserRank");
-export const CompareData = z.unknown().openapi("CompareData");
+const nullableNumber = z.number().nullable();
+
+const LifterMatch = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+  })
+  .openapi("LifterMatch");
+
+const PersonalBest = z
+  .object({
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+    wilks: nullableNumber,
+    units: UnitsSchema,
+  })
+  .openapi("PersonalBest");
+
+const ProfileSummary = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    total_entries: z.number(),
+    first_meet: z.string().nullable(),
+    last_meet: z.string().nullable(),
+    personal_best: PersonalBest,
+  })
+  .openapi("ProfileSummary");
+
+const Attempts = z
+  .object({
+    squat: z.array(nullableNumber).length(4),
+    bench: z.array(nullableNumber).length(4),
+    deadlift: z.array(nullableNumber).length(4),
+  })
+  .openapi("Attempts");
+
+const CompetitionResult = z
+  .object({
+    date: z.string(),
+    meet_name: z.string(),
+    meet_path: z.string(),
+    federation: z.string(),
+    event: EventSchema,
+    equipment: EquipmentSchema,
+    weight_class_kg: nullableNumber,
+    bodyweight: nullableNumber,
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+    place: PlaceSchema,
+    units: UnitsSchema,
+    attempts: Attempts.optional(),
+  })
+  .openapi("CompetitionResult");
+
+const RunningPersonalBest = z
+  .object({
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+  })
+  .openapi("RunningPersonalBest");
+
+const ProgressionEntry = z
+  .object({
+    date: z.string(),
+    meet_name: z.string(),
+    meet_path: z.string(),
+    federation: z.string(),
+    event: EventSchema,
+    equipment: EquipmentSchema,
+    weight_class_kg: nullableNumber,
+    bodyweight: nullableNumber,
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+    place: PlaceSchema,
+    running_pb: RunningPersonalBest,
+    units: UnitsSchema,
+  })
+  .openapi("ProgressionEntry");
+
+const Rank = z
+  .object({
+    rank: z.number(),
+    out_of: z.number(),
+  })
+  .nullable()
+  .openapi("Rank");
+
+const Ranks = z
+  .object({
+    dots: Rank,
+    wilks: Rank,
+    glossbrenner: Rank,
+    goodlift: Rank,
+    total: Rank,
+    squat: Rank,
+    bench: Rank,
+    deadlift: Rank,
+  })
+  .openapi("Ranks");
+
+const Deltas = z
+  .object({
+    squat: nullableNumber,
+    bench: nullableNumber,
+    deadlift: nullableNumber,
+    total: nullableNumber,
+    dots: nullableNumber,
+  })
+  .openapi("Deltas");
+
+export const UserListData = z.array(LifterMatch).openapi("UserListData");
+
+export const UserProfile = ProfileSummary.extend({
+  competition_results: z.array(CompetitionResult),
+}).openapi("UserProfile");
+
+export const PersonalBests = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    total_meets: z.number(),
+    by_equipment: z.array(
+      z.object({
+        equipment: EquipmentSchema,
+        meets: z.number(),
+        personal_best: PersonalBest,
+      }),
+    ),
+  })
+  .openapi("PersonalBestsByEquipment");
+
+export const Progression = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    meets: z.number(),
+    progression: z.array(ProgressionEntry),
+  })
+  .openapi("ProgressionData");
+
+export const UserRank = z
+  .object({
+    username: z.string(),
+    name: z.string(),
+    ranks: Ranks,
+  })
+  .openapi("UserRank");
+
+export const CompareData = z
+  .object({
+    a: ProfileSummary,
+    b: ProfileSummary,
+    deltas: Deltas,
+  })
+  .openapi("CompareData");

--- a/src/routes/api/users/users.ts
+++ b/src/routes/api/users/users.ts
@@ -3,7 +3,7 @@ import { HTTPException } from "hono/http-exception";
 
 import type { AppContext } from "../../../context";
 import type { Units } from "../../../utils/helpers";
-import { errorContent, jsonContent, successResponse } from "../api.schemas";
+import { errorContent, jsonContent, paginatedDataResponse, successResponse } from "../api.schemas";
 import {
   CompareData,
   PersonalBests,
@@ -31,7 +31,7 @@ export function createUsersRouter(context: AppContext) {
       responses: {
         200: {
           description: "Paginated list of lifters (optionally filtered by ?search=)",
-          ...jsonContent(successResponse(UserListData)),
+          ...jsonContent(paginatedDataResponse(UserListData)),
         },
         400: { description: "Validation error", ...errorContent },
         429: { description: "Rate limit exceeded", ...errorContent },


### PR DESCRIPTION
## Summary

- replace all 14 feature response components backed by `z.unknown()` with concrete Zod/OpenAPI schemas
- add shared unit, sex, event, equipment, and placing primitives plus reusable nested response models
- document the `pagination` field already returned by `GET /api/users`
- add regression coverage for generated OpenAPI components and representative runtime payloads

## Root cause

The Express-to-Hono migration replaced the former field-level Swagger definitions with named `z.unknown()` placeholders. Swagger UI correctly rendered those unconstrained components as `any`, and no generated-spec test detected the loss of response typing.

## Impact

Swagger UI and generated API clients now receive field-level types, enum values, nullability, nested structures, and array item schemas for rankings, records, users, meets, and federations. Runtime API behavior is unchanged.

## Verification

- `./node_modules/.bin/vp check`
- `APP_ENV=testing NODE_ENV=testing NODE_NO_WARNINGS=1 ./node_modules/.bin/vp test run`
- 23 test files passed, 144 tests passed
- Linux Chromium integration test against local Swagger UI:
  - all affected component summaries render as `object` or `array<object>`, with no top-level `any`
  - expanded `UserListData` renders `username` and `name` item fields
  - expanded `UserProfile` renders nested properties and `place` as `number | string | null`
  - Swagger `Try it out` for `GET /api/users?per_page=2&units=lbs` returns HTTP 200 with two lifters and pagination metadata
