### PR TITLE
feat(api) - Add missing common age groups to ageClassEnum

### DIFF
--- a/src/routes/api/rankings/rankings.schema.ts
+++ b/src/routes/api/rankings/rankings.schema.ts
@@ -34,7 +34,13 @@ export const sortEnum = z.enum([
 ]);
 
 export const ageClassEnum = z.enum([
+  "5-12",
+  "13-15",
+  "16-17",
+  "18-19",
+  "20-23",
   "24-34",
+  "35-39",
   "40-44",
   "45-49",
   "50-54",
@@ -43,6 +49,8 @@ export const ageClassEnum = z.enum([
   "65-69",
   "70-74",
   "75-79",
+  "80-84",
+  "85-89",
 ]);
 
 const baseQuery = z.object({


### PR DESCRIPTION
When working with the API, I noticed that some of the common filterable age groups were missing from the API. This adds the common ones to reach parity with the main site.

Happy to make any additional changes that you see fit. 

Thanks!